### PR TITLE
Fix copy paste mistake in spec name

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -195,8 +195,8 @@ var _ = Describe("Tracker Client", func() {
 		})
 	})
 
-	Describe("listing stories", func() {
-		It("gets all the stories by default", func() {
+	Describe("listing project memberships", func() {
+		It("gets all the project memberships", func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/services/v5/projects/99/memberships"),


### PR DESCRIPTION
Tidying up a mistake I added in [PR#8](https://github.com/xoebus/go-tracker/pull/8). Thanks!