### PR TITLE
Retrieve tracker story without passing project ID

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,6 +13,10 @@
 // limitations under the License.
 package tracker
 
+import (
+	"fmt"
+)
+
 var DefaultURL = "https://www.pivotaltracker.com"
 
 type Client struct {
@@ -41,4 +45,21 @@ func (c Client) InProject(projectId int) ProjectClient {
 		id:   projectId,
 		conn: c.conn,
 	}
+}
+
+func (c Client) Story(storyID int) (Story, error) {
+	url := fmt.Sprintf("/stories/%d", storyID)
+	request, err := c.conn.CreateRequest("GET", url, nil)
+	if err != nil {
+		return Story{}, err
+	}
+
+	var story Story
+	_, err = c.conn.Do(request, &story)
+
+	if err != nil {
+		return Story{}, err
+	}
+
+	return story, err
 }

--- a/client_test.go
+++ b/client_test.go
@@ -118,6 +118,27 @@ var _ = Describe("Tracker Client", func() {
 		})
 	})
 
+
+	Describe("retrieving a story by ID", func(){
+		It("gets one story", func(){
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/services/v5/stories/560"),
+					verifyTrackerToken(),
+
+					ghttp.RespondWith(http.StatusOK, Fixture("story.json")),
+				),
+			)
+
+			client := tracker.NewClient("api-token")
+
+			story, err := client.Story(560)
+			Ω(err).ToNot(HaveOccurred())
+			Ω(story.ID).To(Equal(560))
+			Ω(story.Name).To(Equal("Tractor beam loses power intermittently"))
+		})
+	})
+
 	Describe("listing stories", func() {
 		It("gets all the stories by default", func() {
 			server.AppendHandlers(

--- a/fixtures/story.json
+++ b/fixtures/story.json
@@ -1,0 +1,21 @@
+{
+  "kind": "story",
+  "id": 560,
+  "created_at": "2015-07-20T22:50:50Z",
+  "updated_at": "2015-07-20T22:51:50Z",
+  "accepted_at": "2015-07-20T22:52:50Z",
+  "story_type": "bug",
+  "name": "Tractor beam loses power intermittently",
+  "current_state": "finished",
+  "requested_by_id": 102,
+  "project_id": 99,
+  "url": "http://localhost/story/show/560",
+  "owner_ids":
+  [
+  ],
+  "labels":
+  [
+    { "id": 10, "project_id": 99, "name": "some-label" },
+    { "id": 11, "project_id": 99, "name": "some-other-label" }
+  ]
+}


### PR DESCRIPTION
This allows querying for a story based solely on the story ID, aka you don't need to know which project it belongs to.