### PR TITLE
Add support for blockers APIs

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -370,14 +370,18 @@ var _ = Describe("Tracker Client", func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("POST", "/services/v5/projects/99/stories"),
-					ghttp.VerifyJSON(`{"name":"Exhaust ports are ray shielded"}`),
+					ghttp.VerifyJSON(`{"name":"Exhaust ports are ray shielded","blockers":[{"id":5,"description":"something"}]}`),
 					verifyTrackerToken(),
 
 					ghttp.RespondWith(http.StatusOK, `{
 						"id": 1234,
 						"project_id": 5678,
 						"name": "Exhaust ports are ray shielded",
-						"url": "https://some-url.biz/1234"
+						"url": "https://some-url.biz/1234",
+						"blockers":
+						[
+						 {"id": 5, "description": "something"}
+						]
 					}`),
 				),
 			)
@@ -386,6 +390,12 @@ var _ = Describe("Tracker Client", func() {
 
 			story, err := client.InProject(99).CreateStory(tracker.Story{
 				Name: "Exhaust ports are ray shielded",
+				Blockers: []tracker.Blocker{
+					{
+						ID:          5,
+						Description: "something",
+					},
+				},
 			})
 			Ω(story).Should(Equal(tracker.Story{
 				ID:        1234,
@@ -394,6 +404,12 @@ var _ = Describe("Tracker Client", func() {
 				Name: "Exhaust ports are ray shielded",
 
 				URL: "https://some-url.biz/1234",
+				Blockers: []tracker.Blocker{
+					{
+						ID:          5,
+						Description: "something",
+					},
+				},
 			}))
 			Ω(err).ShouldNot(HaveOccurred())
 		})
@@ -494,7 +510,7 @@ var _ = Describe("Tracker Client", func() {
 			})
 
 			Expect(blocker).Should(Equal(tracker.Blocker{
-				ID: 111,
+				ID:          111,
 				Description: "some-tracker-blocker",
 			}))
 			Expect(err).ShouldNot(HaveOccurred())

--- a/client_test.go
+++ b/client_test.go
@@ -466,6 +466,40 @@ var _ = Describe("Tracker Client", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 		})
 	})
+
+	Describe("creating a blocker", func() {
+		It("POSTs", func() {
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", "/services/v5/projects/99/stories/560/blockers"),
+					ghttp.VerifyJSON(`{"description":"some-tracker-blocker"}`),
+					verifyTrackerToken(),
+
+					ghttp.RespondWith(http.StatusOK, `{
+			          "kind": "blocker",
+                      "id": 111,
+                      "story_id": 560,
+                      "description": "some-tracker-blocker",
+                      "person_id": 101,
+                      "created_at": "2017-03-07T12:00:00Z",
+                      "updated_at": "2017-03-07T12:00:00Z"
+					}`),
+				),
+			)
+
+			client := tracker.NewClient("api-token")
+
+			blocker, err := client.InProject(99).CreateBlocker(560, tracker.Blocker{
+				Description: "some-tracker-blocker",
+			})
+
+			Expect(blocker).Should(Equal(tracker.Blocker{
+				ID: 111,
+				Description: "some-tracker-blocker",
+			}))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
 })
 
 func verifyTrackerToken() http.HandlerFunc {

--- a/fixtures/stories.json
+++ b/fixtures/stories.json
@@ -18,6 +18,11 @@
        [
          { "id": 10, "project_id": 99, "name": "some-label" },
          { "id": 11, "project_id": 99, "name": "some-other-label" }
+       ],
+       "blockers":
+       [
+           {"id": 12, "description": "some blocker"},
+           {"id": 13, "description": "some other blocker"}
        ]
    },
    {
@@ -45,6 +50,15 @@
                "created_at": "2015-07-20T22:50:50Z",
                "updated_at": "2015-07-20T22:50:50Z"
            }
+       ],
+       "blockers":
+       [
+           {
+               "id": 12,
+               "description": "some blocker",
+               "created_at": "2015-07-20T22:50:50Z",
+               "person_id": 789998
+           }
        ]
    },
    {
@@ -65,6 +79,9 @@
        ],
        "labels":
        [
+       ],
+       "blockers":
+       [
        ]
    },
    {
@@ -84,6 +101,9 @@
        [
        ],
        "labels":
+       [
+       ],
+       "blockers":
        [
        ]
    }

--- a/fixtures/story.json
+++ b/fixtures/story.json
@@ -1,0 +1,26 @@
+{
+  "kind": "story",
+  "id": 560,
+  "created_at": "2015-07-20T22:50:50Z",
+  "updated_at": "2015-07-20T22:51:50Z",
+  "accepted_at": "2015-07-20T22:52:50Z",
+  "story_type": "bug",
+  "name": "Tractor beam loses power intermittently",
+  "current_state": "finished",
+  "requested_by_id": 102,
+  "project_id": 99,
+  "url": "http://localhost/story/show/560",
+  "owner_ids":
+  [
+  ],
+  "labels":
+  [
+    { "id": 10, "project_id": 99, "name": "some-label" },
+    { "id": 11, "project_id": 99, "name": "some-other-label" }
+  ],
+  "blockers":
+  [
+    {"id": 12, "description": "some blocker"},
+    {"id": 13, "description": "some other blocker"}
+  ]
+}

--- a/project_client.go
+++ b/project_client.go
@@ -148,6 +148,23 @@ func (p ProjectClient) CreateTask(storyID int, task Task) (Task, error) {
 	return createdTask, err
 }
 
+func (p ProjectClient) CreateBlocker(storyID int, blocker Blocker) (Blocker, error) {
+	url := fmt.Sprintf("/stories/%d/blockers", storyID)
+	request, err := p.createRequest("POST", url, nil)
+	if err != nil {
+		return Blocker{}, err
+	}
+
+	buffer := &bytes.Buffer{}
+	json.NewEncoder(buffer).Encode(blocker)
+
+	p.addJSONBodyReader(request, buffer)
+
+	var createdBlocker Blocker
+	_, err = p.conn.Do(request, &createdBlocker)
+	return createdBlocker, err
+}
+
 func (p ProjectClient) ProjectMemberships() ([]ProjectMembership, error) {
 	request, err := p.createRequest("GET", "/memberships", nil)
 	if err != nil {

--- a/resources.go
+++ b/resources.go
@@ -45,6 +45,7 @@ type Story struct {
 	CreatedAt  *time.Time `json:"created_at,omitempty"`
 	UpdatedAt  *time.Time `json:"updated_at,omitempty"`
 	AcceptedAt *time.Time `json:"accepted_at,omitempty"`
+	Blockers   []Blocker  `json:"blockers,omitempty"`
 }
 
 type Task struct {

--- a/resources.go
+++ b/resources.go
@@ -63,6 +63,11 @@ type Comment struct {
 	Text string `json:"text,omitempty"`
 }
 
+type Blocker struct {
+	ID          int    `json:"id,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
 type Label struct {
 	ID        int `json:"id,omitempty"`
 	ProjectID int `json:"project_id,omitempty"`

--- a/resources_test.go
+++ b/resources_test.go
@@ -53,9 +53,14 @@ var _ = Describe("Story", func() {
 			{ID: 10, ProjectID: 99, Name: "some-label"},
 			{ID: 11, ProjectID: 99, Name: "some-other-label"},
 		}))
-		Ω(*story.CreatedAt).Should(Equal(time.Date(2015, 07, 20, 22, 50, 50, 0, time.UTC)))
-		Ω(*story.UpdatedAt).Should(Equal(time.Date(2015, 07, 20, 22, 51, 50, 0, time.UTC)))
-		Ω(*story.AcceptedAt).Should(Equal(time.Date(2015, 07, 20, 22, 52, 50, 0, time.UTC)))
+
+		Ω(*story.CreatedAt).To(Equal(time.Date(2015, 07, 20, 22, 50, 50, 0, time.UTC)))
+		Ω(*story.UpdatedAt).To(Equal(time.Date(2015, 07, 20, 22, 51, 50, 0, time.UTC)))
+		Ω(*story.AcceptedAt).To(Equal(time.Date(2015, 07, 20, 22, 52, 50, 0, time.UTC)))
+		Ω(story.Blockers).To(Equal([]tracker.Blocker{
+			{ID: 12, Description: "some blocker"},
+			{ID: 13, Description: "some other blocker"},
+		}))
 	})
 })
 


### PR DESCRIPTION
This adds support for both creating blockers on an existing story as well as creating a story with blockers all in one request.